### PR TITLE
Increase Column Size for Signatures

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/entity/SignerInformationEntity.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/entity/SignerInformationEntity.java
@@ -75,7 +75,7 @@ public class SignerInformationEntity {
     /**
      * Signature of the TrustAnchor.
      */
-    @Column(name = "signature", nullable = false, length = 1000)
+    @Column(name = "signature", nullable = false, length = 6000)
     String signature;
 
     /**

--- a/src/main/java/eu/europa/ec/dgc/gateway/entity/TrustedPartyEntity.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/entity/TrustedPartyEntity.java
@@ -71,7 +71,7 @@ public class TrustedPartyEntity {
     /**
      * Signature of the TrustAnchor.
      */
-    @Column(name = "signature", nullable = false, length = 1000)
+    @Column(name = "signature", nullable = false, length = 6000)
     String signature;
 
     /**

--- a/src/main/resources/db/changelog/init-tables.xml
+++ b/src/main/resources/db/changelog/init-tables.xml
@@ -22,7 +22,7 @@
             <column name="raw_data" type="VARCHAR(4096)">
                 <constraints nullable="false"/>
             </column>
-            <column name="signature" type="VARCHAR(1000)">
+            <column name="signature" type="VARCHAR(6000)">
                 <constraints nullable="false"/>
             </column>
             <column name="certificate_type" type="VARCHAR(255)">
@@ -47,7 +47,7 @@
             <column name="raw_data" type="VARCHAR(4096)">
                 <constraints nullable="false"/>
             </column>
-            <column name="signature" type="VARCHAR(1000)">
+            <column name="signature" type="VARCHAR(6000)">
                 <constraints nullable="false"/>
             </column>
             <column name="certificate_type" type="VARCHAR(255)">


### PR DESCRIPTION
Increase Signature Column Size to 6000 for 4096 bit sized CMS signatures