### PR TITLE
Fix: CSCA Verification Error

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
@@ -38,6 +38,7 @@ import org.bouncycastle.cert.CertException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.operator.ContentVerifierProvider;
 import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.RuntimeOperatorException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.springframework.stereotype.Service;
 
@@ -243,8 +244,9 @@ public class SignerInformationService {
 
         try {
             return certificate.isSignatureValid(verifier);
-        } catch (CertException e) {
+        } catch (CertException | RuntimeOperatorException e) {
             log.error("Could not verify certificate issuance.");
+            log.debug("Could not verify certificate issuance: {}", e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
We experienced an issue at validating CSCA when DSC was signed with 2048 Bit CA and only 4096 Bit CSCA are whitelisted. The validation crashes and gateway returns 500 error code.

This PR adds the thrown Exception to the catch block of .isSignatureValid() method to catch these exceptions and return correct ```false``` result.