### PR TITLE
Fix: Certificate Hash in Audit Events

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
@@ -132,7 +132,8 @@ public class SignerCertificateController {
             log.error("Verification certificate upload failed: {}: {}", e.getReason(), e.getMessage());
             String sentValues = String.format("{%s} country:{%s}", cms, countryCode);
             if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.ALREADY_EXIST_CHECK_FAILED) {
-                throw new DgcgResponseException(HttpStatus.CONFLICT, "0x002", "You cant upload an existing certificate.",
+                throw new DgcgResponseException(HttpStatus.CONFLICT, "0x002",
+                    "You cant upload an existing certificate.",
                     sentValues, e.getMessage());
             } else if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.UPLOAD_FAILED) {
                 auditService.addAuditEvent(

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
@@ -114,7 +114,8 @@ public class SignerCertificateController {
     )
     public ResponseEntity<Void> postVerificationInformation(
         @RequestBody SignedCertificateDto cms,
-        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_COUNTRY) String countryCode
+        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_COUNTRY) String countryCode,
+        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_THUMBPRINT) String authThumbprint
     ) {
 
         log.info("Uploading new verification certificate, signing cert: {}, payload cert: {}",
@@ -129,28 +130,39 @@ public class SignerCertificateController {
                 countryCode);
         } catch (SignerInformationService.SignerCertCheckException e) {
             log.error("Verification certificate upload failed: {}: {}", e.getReason(), e.getMessage());
-            String sentValues = String.format("{%s} country:{%s}",cms,countryCode);
+            String sentValues = String.format("{%s} country:{%s}", cms, countryCode);
             if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.ALREADY_EXIST_CHECK_FAILED) {
-                throw new DgcgResponseException(HttpStatus.CONFLICT, "0x002","You cant upload an existing certificate.",
-                        sentValues,e.getMessage());
+                throw new DgcgResponseException(HttpStatus.CONFLICT, "0x002", "You cant upload an existing certificate.",
+                    sentValues, e.getMessage());
             } else if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.UPLOAD_FAILED) {
-                auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                        cms.getPayloadCertificate().toString(), "UPLOAD_FAILED",
-                        "postVerificationInformation triggered UPLOAD_FAILED");
+                auditService.addAuditEvent(
+                    countryCode,
+                    cms.getSignerCertificate(),
+                    authThumbprint,
+                    "UPLOAD_FAILED",
+                    "postVerificationInformation triggered UPLOAD_FAILED");
+
                 throw new DgcgResponseException(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "0x003","Upload of Signer Certificate failed",sentValues,e.getMessage());
+                    "0x003", "Upload of Signer Certificate failed", sentValues, e.getMessage());
             } else {
-                auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                        cms.getPayloadCertificate().toString(), "BAD_REQUEST",
-                        "postVerificationInformation triggered BAD_REQUEST");
-                throw new DgcgResponseException(HttpStatus.BAD_REQUEST, "0x004","Possible reasons: Wrong Format,"
-                        + " no CMS, not the correct signing alg missing attributes, invalid signature, certificate not "
-                        + "signed by known CA",sentValues,e.getMessage());
+                auditService.addAuditEvent(
+                    countryCode,
+                    cms.getSignerCertificate(),
+                    authThumbprint,
+                    "BAD_REQUEST",
+                    "postVerificationInformation triggered BAD_REQUEST");
+
+                throw new DgcgResponseException(HttpStatus.BAD_REQUEST, "0x004", "Possible reasons: Wrong Format,"
+                    + " no CMS, not the correct signing alg missing attributes, invalid signature, certificate not "
+                    + "signed by known CA", sentValues, e.getMessage());
             }
         }
-        auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                cms.getPayloadCertificate().toString(), "SUCCESS",
-                "postVerificationInformation successful executed");
+        auditService.addAuditEvent(
+            countryCode,
+            cms.getSignerCertificate(),
+            authThumbprint,
+            "SUCCESS",
+            "postVerificationInformation successful executed");
         return ResponseEntity.status(201).build();
     }
 
@@ -205,7 +217,8 @@ public class SignerCertificateController {
     )
     public ResponseEntity<Void> revokeVerificationInformation(
         @RequestBody SignedCertificateDto cms,
-        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_COUNTRY) String countryCode
+        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_COUNTRY) String countryCode,
+        @RequestAttribute(CertificateAuthenticationFilter.REQUEST_PROP_THUMBPRINT) String authThumbprint
     ) {
 
         log.info("Revoking verification certificate, signing cert: {}, payload cert: {}",
@@ -219,32 +232,48 @@ public class SignerCertificateController {
                 countryCode);
         } catch (SignerInformationService.SignerCertCheckException e) {
             log.error("Verification certificate delete failed: {}: {}", e.getReason(), e.getMessage());
-            String sentValues = String.format("{%s} country:{%s}",cms,countryCode);
+            String sentValues = String.format("{%s} country:{%s}", cms, countryCode);
             if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.EXIST_CHECK_FAILED) {
-                auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                        cms.getPayloadCertificate().toString(), "EXIST_CHECK_FAILED",
-                        "revokeVerificationInformation triggered EXIST_CHECK_FAILED");
+                auditService.addAuditEvent(
+                    countryCode,
+                    cms.getSignerCertificate(),
+                    authThumbprint,
+                    "EXIST_CHECK_FAILED",
+                    "revokeVerificationInformation triggered EXIST_CHECK_FAILED");
+
                 throw new DgcgResponseException(HttpStatus.NOT_FOUND, "0x005",
-                        "The certificate doesn't exists in the database.",
-                        sentValues,e.getMessage());
+                    "The certificate doesn't exists in the database.",
+                    sentValues, e.getMessage());
             } else if (e.getReason() == SignerInformationService.SignerCertCheckException.Reason.UPLOAD_FAILED) {
-                auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                        cms.getPayloadCertificate().toString(), "UPLOAD_FAILED",
-                        "revokeVerificationInformation triggered UPLOAD_FAILED");
+                auditService.addAuditEvent(
+                    countryCode,
+                    cms.getSignerCertificate(),
+                    authThumbprint,
+                    "UPLOAD_FAILED",
+                    "revokeVerificationInformation triggered UPLOAD_FAILED");
+
                 throw new DgcgResponseException(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "0x006","Upload of Signer Certificate failed",sentValues,e.getMessage());
+                    "0x006", "Upload of Signer Certificate failed", sentValues, e.getMessage());
             } else {
-                auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                        cms.getPayloadCertificate().toString(), "BAD_REQUEST",
-                        "revokeVerificationInformation triggered BAD_REQUEST");
-                throw new DgcgResponseException(HttpStatus.BAD_REQUEST, "0x007","Possible reasons: Wrong Format,"
-                        + " no CMS, not the correct signing alg missing attributes, invalid signature, certificate not "
-                        + "signed by known CA",sentValues,e.getMessage());
+                auditService.addAuditEvent(
+                    countryCode,
+                    cms.getSignerCertificate(),
+                    authThumbprint,
+                    "BAD_REQUEST",
+                    "revokeVerificationInformation triggered BAD_REQUEST");
+
+                throw new DgcgResponseException(HttpStatus.BAD_REQUEST, "0x007", "Possible reasons: Wrong Format,"
+                    + " no CMS, not the correct signing alg missing attributes, invalid signature, certificate not "
+                    + "signed by known CA", sentValues, e.getMessage());
             }
         }
-        auditService.addAuditEvent(countryCode,cms.getSignerCertificate().toString(),
-                cms.getPayloadCertificate().toString(), "SUCCESS",
-                "revokeVerificationInformation triggered SUCCESS ");
+        auditService.addAuditEvent(
+            countryCode,
+            cms.getSignerCertificate(),
+            authThumbprint,
+            "SUCCESS",
+            "revokeVerificationInformation triggered SUCCESS");
+
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/AuditService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/AuditService.java
@@ -2,29 +2,55 @@ package eu.europa.ec.dgc.gateway.service;
 
 import eu.europa.ec.dgc.gateway.entity.AuditEventEntity;
 import eu.europa.ec.dgc.gateway.repository.AuditEventRepository;
+import eu.europa.ec.dgc.utils.CertificateUtils;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.cert.X509CertificateHolder;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class AuditService {
+
     private final AuditEventRepository auditEventRepository;
+
+    private final CertificateUtils certificateUtils;
 
     /**
      * Method to create an audit Event.
      *
-     * @param countryCode 2-digit country Code
-     * @param uploaderSha256Fingerprint     fingerprint of the uploader cert
+     * @param countryCode                     2-digit country Code
+     * @param uploaderCertificate             the uploader cert
      * @param authenticationSha256Fingerprint fingerprint of the authentication cert
-     * @param auditEvent Event ID
-     * @param auditEventDescription EventDescription
+     * @param auditEvent                      Event ID
+     * @param auditEventDescription           EventDescription
+     */
+    public void addAuditEvent(String countryCode, X509CertificateHolder uploaderCertificate,
+                              String authenticationSha256Fingerprint,
+                              String auditEvent, String auditEventDescription) {
+        addAuditEvent(
+            countryCode,
+            certificateUtils.getCertThumbprint(uploaderCertificate),
+            authenticationSha256Fingerprint,
+            auditEvent,
+            auditEventDescription
+        );
+    }
+
+    /**
+     * Method to create an audit Event.
+     *
+     * @param countryCode                     2-digit country Code
+     * @param uploaderSha256Fingerprint       fingerprint of the uploader cert
+     * @param authenticationSha256Fingerprint fingerprint of the authentication cert
+     * @param auditEvent                      Event ID
+     * @param auditEventDescription           EventDescription
      */
     public void addAuditEvent(String countryCode, String uploaderSha256Fingerprint,
-                              String authenticationSha256Fingerprint,String  auditEvent, String auditEventDescription) {
+                              String authenticationSha256Fingerprint, String auditEvent, String auditEventDescription) {
         AuditEventEntity auditEventEntity = new AuditEventEntity();
         auditEventEntity.setEvent(auditEvent);
         auditEventEntity.setDescription(auditEventDescription);
@@ -33,7 +59,7 @@ public class AuditService {
         auditEventEntity.setAuthenticationSha256Fingerprint(authenticationSha256Fingerprint);
         auditEventEntity.setUploaderSha256Fingerprint(uploaderSha256Fingerprint);
         log.debug("Created AuditEvent with ID {} for Country {} with uploader {} authentication{}", auditEvent,
-                countryCode, uploaderSha256Fingerprint, authenticationSha256Fingerprint);
+            countryCode, uploaderSha256Fingerprint, authenticationSha256Fingerprint);
         log.info("Created AuditEvent with ID {} for Country {} ", auditEvent, countryCode);
         auditEventRepository.save(auditEventEntity);
     }

--- a/src/test/java/eu/europa/ec/dgc/gateway/service/AuditServiceTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/service/AuditServiceTest.java
@@ -1,6 +1,10 @@
 package eu.europa.ec.dgc.gateway.service;
 
+import eu.europa.ec.dgc.gateway.entity.AuditEventEntity;
+import eu.europa.ec.dgc.gateway.entity.TrustedPartyEntity;
 import eu.europa.ec.dgc.gateway.repository.AuditEventRepository;
+import eu.europa.ec.dgc.gateway.testdata.TrustedPartyTestHelper;
+import eu.europa.ec.dgc.utils.CertificateUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,21 +12,62 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class AuditServiceTest {
+
     @Autowired
     AuditService auditService;
+
     @Autowired
     AuditEventRepository auditEventRepository;
+
+    @Autowired
+    TrustedPartyTestHelper trustedPartyTestHelper;
+
+    @Autowired
+    CertificateUtils certificateUtils;
 
     private static final String countryCode = "EU";
     private static final String dummySignature = "randomStringAsSignatureWhichIsNotValidatedInServiceLevel";
 
     @Test
-    void testSuccessfulCreateAuditEvent() throws Exception {
-        long count = auditEventRepository.count() + 1;
+    void testSuccessfulCreateAuditEvent() {
+        auditEventRepository.deleteAll();
+        String exampleEvent = "postVerificationInformation_ALREADY_EXIST_CHECK_FAILED";
+        String exampleEventDescription = "ALREADY_EXIST_CHECK_FAILED";
 
-        auditService.addAuditEvent(countryCode,dummySignature,
-                dummySignature, "postVerificationInformation_ALREADY_EXIST_CHECK_FAILED", "ALREADY_EXIST_CHECK_FAILED");
+        auditService.addAuditEvent(countryCode, dummySignature,
+            dummySignature, exampleEvent, exampleEventDescription);
 
-        Assertions.assertEquals(count, auditEventRepository.count());
+        Assertions.assertEquals(1, auditEventRepository.count());
+        AuditEventEntity auditEvent = auditEventRepository.findAll().get(0);
+
+        Assertions.assertEquals(countryCode, auditEvent.getCountry());
+        Assertions.assertEquals(dummySignature, auditEvent.getAuthenticationSha256Fingerprint());
+        Assertions.assertEquals(dummySignature, auditEvent.getUploaderSha256Fingerprint());
+        Assertions.assertEquals(exampleEvent, auditEvent.getEvent());
+        Assertions.assertEquals(exampleEventDescription, auditEvent.getDescription());
+    }
+
+    @Test
+    void testSuccessfulCreateAuditEventWithCertificate() throws Exception {
+        auditEventRepository.deleteAll();
+        String exampleEvent = "postVerificationInformation_ALREADY_EXIST_CHECK_FAILED";
+        String exampleEventDescription = "ALREADY_EXIST_CHECK_FAILED";
+
+        auditService.addAuditEvent(
+            countryCode,
+            certificateUtils.convertCertificate(
+                trustedPartyTestHelper.getCert(TrustedPartyEntity.CertificateType.UPLOAD, countryCode)),
+            dummySignature,
+            exampleEvent,
+            exampleEventDescription);
+
+        Assertions.assertEquals(1, auditEventRepository.count());
+        AuditEventEntity auditEvent = auditEventRepository.findAll().get(0);
+
+        Assertions.assertEquals(countryCode, auditEvent.getCountry());
+        Assertions.assertEquals(dummySignature, auditEvent.getAuthenticationSha256Fingerprint());
+        Assertions.assertEquals(trustedPartyTestHelper.getHash(TrustedPartyEntity.CertificateType.UPLOAD, countryCode), auditEvent.getUploaderSha256Fingerprint());
+        Assertions.assertEquals(exampleEvent, auditEvent.getEvent());
+        Assertions.assertEquals(exampleEventDescription, auditEvent.getDescription());
     }
 }


### PR DESCRIPTION
The Audit Events are currently logging the .toString() of certificates.
I've changed it to use the hash of certificate.