### PR TITLE
Fix: Typo in OpenAPI Spec

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
@@ -150,7 +150,7 @@ public class TrustListController {
                 schema = @Schema(implementation = CertificateTypeDto.class)),
             @Parameter(
                 in = ParameterIn.PATH,
-                name = "county",
+                name = "country",
                 description = "2-Digit Country Code to filter for",
                 example = "EU",
                 required = true)


### PR DESCRIPTION
OpenAPI Spec for TrustList download filtered by type and country has a wrong parameter county.