### PR TITLE
Fix: Add BouncyCastleProvider to JavaSecurity

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/config/BouncyCastleConfig.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/config/BouncyCastleConfig.java
@@ -1,0 +1,13 @@
+package eu.europa.ec.dgc.gateway.config;
+
+import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BouncyCastleConfig {
+
+    public BouncyCastleConfig() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+}

--- a/src/main/java/eu/europa/ec/dgc/gateway/config/BouncyCastleConfig.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/config/BouncyCastleConfig.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class BouncyCastleConfig {
 
+    /**
+     * Adds BouncyCastle as Provider for JavaSecurity.
+     */
     public BouncyCastleConfig() {
         Security.addProvider(new BouncyCastleProvider());
     }


### PR DESCRIPTION
Some MS had problems uploading certs signed with SHA256withRSASSA-PSS.
Adding BouncyCastle as SecurityProvider will fix this issue.