### PR TITLE
Add Alias for Delete/Revoke Endpoint

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
@@ -172,6 +172,7 @@ public class SignerCertificateController {
      */
     @CertificateAuthenticationRequired
     @DeleteMapping(path = "", consumes = CmsMessageConverter.CONTENT_TYPE_CMS_VALUE)
+    @PostMapping(path = "delete", consumes = CmsMessageConverter.CONTENT_TYPE_CMS_VALUE)
     @Operation(
         summary = "Revokes Signer Certificate of a trusted Issuer",
         tags = {"Signer Information"},


### PR DESCRIPTION
This PR adds a new alias for the delete/revoke endpoint.

This Alias is introduced to support Load Balancers which are removing the payload when sending DELETE requests.

This PR closes #63 