### PR TITLE
Add Logging for Downloaded Keys

### DIFF
--- a/docs/software-design-dgc-gateway.md
+++ b/docs/software-design-dgc-gateway.md
@@ -193,6 +193,8 @@ These key-value-pairs can be followed by additional attributes. The additional a
 | Created new AuditEvent (id = event type) | INFO | Created AuditEvent | auditId, country |
 | **General**
 | Uncaught Exception was thrown in DGCG | ERROR | Uncaught exception | exception |
+| **Download Interface**
+| Trust List was downloaded by a country | INFO | Downloaded TrustList | downloadedKeys (Number of Keys), downloadedKeysCountry (Downloader Country), downloadedKeysType (optional) | 
 
 
  

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
@@ -65,6 +65,7 @@ public class TrustListController {
     private static final String MDC_PROP_DOWNLOAD_KEYS_COUNT = "downloadedKeys";
     private static final String MDC_PROP_DOWNLOAD_KEYS_TYPE = "downloadedKeysType";
     private static final String MDC_PROP_DOWNLOAD_KEYS_COUNTRY = "downloadedKeysCountry";
+    private static final String DOWNLOADED_TRUSTLIST_LOG_MESSAGE = "Downloaded TrustList";
 
     /**
      * TrustList Download Controller.
@@ -97,7 +98,7 @@ public class TrustListController {
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_COUNT, trustList.size());
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_COUNTRY, downloaderCountryCode);
 
-        log.info("Downloaded TrustList");
+        log.info(DOWNLOADED_TRUSTLIST_LOG_MESSAGE);
 
         return ResponseEntity.ok(trustList);
     }
@@ -154,7 +155,7 @@ public class TrustListController {
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_TYPE, type.name());
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_COUNTRY, downloaderCountryCode);
 
-        log.info("Downloaded TrustList");
+        log.info(DOWNLOADED_TRUSTLIST_LOG_MESSAGE);
 
         return ResponseEntity.ok(trustList);
     }
@@ -219,7 +220,7 @@ public class TrustListController {
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_TYPE, type.name());
         DgcMdc.put(MDC_PROP_DOWNLOAD_KEYS_COUNTRY, downloaderCountryCode);
 
-        log.info("Downloaded TrustList");
+        log.info(DOWNLOADED_TRUSTLIST_LOG_MESSAGE);
 
         return ResponseEntity.ok(trustList);
     }


### PR DESCRIPTION
This PR adds log messages when keys (TrustLists) were downloaded by a country.
The amount of keys, the downloader country and (if provided) the type of certificates is logged.