### PR TITLE
Fix MDC Parameter name for Verification Errors

### DIFF
--- a/docs/software-design-dgc-gateway.md
+++ b/docs/software-design-dgc-gateway.md
@@ -183,8 +183,8 @@ These key-value-pairs can be followed by additional attributes. The additional a
 | **Certificate Upload Check**
 | Verifier for certificate could not be instantiated. | ERROR | Failed to instantiate JcaContentVerifierProvider from cert | certHash |
 | Certificate Issuer Check has failed | ERROR | Could not verify certificate issuance. | exception |
-| Check of uploaded certificate has failed when revoking a certificate | ERROR | Verification certificate delete failed | reason, message |
-| Check of uploaded certificate has failed when uploading a certificate | ERROR | Verification certificate upload failed | reason, message |
+| Check of uploaded certificate has failed when revoking a certificate | ERROR | Verification certificate delete failed | verificationFailureReason, verificationFailureMessage |
+| Check of uploaded certificate has failed when uploading a certificate | ERROR | Verification certificate upload failed | verificationFailureReason, verificationFailureReasonMessage |
 | Revoking Certificate | INFO | Revoking verification certificate | signerCertSubject, payloadCertSubject |
 | Uploading Certificate | INFO | Uploading new verification certificate | signerCertSubject, payloadCertSubject |
 | Saving Certificate into DB (All checks passed) | INFO | Saving new SignerInformation Entity | uploadCertThumbprint, cscaCertThumbprint |

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/SignerCertificateController.java
@@ -58,6 +58,9 @@ public class SignerCertificateController {
 
     private final AuditService auditService;
 
+    private static final String MDC_VERIFICATION_ERROR_REASON = "verificationFailureReason";
+    private static final String MDC_VERIFICATION_ERROR_MESSAGE = "verificationFailureMessage";
+
     /**
      * VerificationInformation Upload Controller.
      */
@@ -131,8 +134,8 @@ public class SignerCertificateController {
                 cms.getSignature(),
                 countryCode);
         } catch (SignerInformationService.SignerCertCheckException e) {
-            DgcMdc.put("reason", e.getReason().toString());
-            DgcMdc.put("message", e.getMessage());
+            DgcMdc.put(MDC_VERIFICATION_ERROR_REASON, e.getReason().toString());
+            DgcMdc.put(MDC_VERIFICATION_ERROR_MESSAGE, e.getMessage());
             log.error("Verification certificate upload failed");
 
             String sentValues = String.format("{%s} country:{%s}", cms, countryCode);
@@ -238,8 +241,8 @@ public class SignerCertificateController {
                 cms.getSignerCertificate(),
                 countryCode);
         } catch (SignerInformationService.SignerCertCheckException e) {
-            DgcMdc.put("reason", e.getReason().toString());
-            DgcMdc.put("message", e.getMessage());
+            DgcMdc.put(MDC_VERIFICATION_ERROR_REASON, e.getReason().toString());
+            DgcMdc.put(MDC_VERIFICATION_ERROR_MESSAGE, e.getMessage());
             log.error("Verification certificate delete failed");
 
             String sentValues = String.format("{%s} country:{%s}", cms, countryCode);


### PR DESCRIPTION
The MDC Parameter "messages" creates a conflict with existing log message structure.