### PR TITLE
Fix: Missing Download of Rules Valid only in Future

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/ValidationRuleRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/ValidationRuleRepository.java
@@ -43,6 +43,8 @@ public interface ValidationRuleRepository extends JpaRepository<ValidationRuleEn
     List<Long> getIdByValidFromIsBeforeAndRuleIdIs(
         @Param("threshold") ZonedDateTime threshold, @Param("ruleId") String ruleId, Pageable pageable);
 
+    List<ValidationRuleEntity> getByRuleIdAndValidFromIsGreaterThanEqualOrderByIdDesc(String ruleId, ZonedDateTime threshold);
+
     @Query("SELECT max(v.id) FROM ValidationRuleEntity v WHERE v.country = :country GROUP BY v.ruleId")
     List<Long> getLatestIds(@Param("country") String countryCode);
 

--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/ValidationRuleRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/ValidationRuleRepository.java
@@ -43,7 +43,8 @@ public interface ValidationRuleRepository extends JpaRepository<ValidationRuleEn
     List<Long> getIdByValidFromIsBeforeAndRuleIdIs(
         @Param("threshold") ZonedDateTime threshold, @Param("ruleId") String ruleId, Pageable pageable);
 
-    List<ValidationRuleEntity> getByRuleIdAndValidFromIsGreaterThanEqualOrderByIdDesc(String ruleId, ZonedDateTime threshold);
+    List<ValidationRuleEntity> getByRuleIdAndValidFromIsGreaterThanEqualOrderByIdDesc(
+        String ruleId, ZonedDateTime threshold);
 
     @Query("SELECT max(v.id) FROM ValidationRuleEntity v WHERE v.country = :country GROUP BY v.ruleId")
     List<Long> getLatestIds(@Param("country") String countryCode);

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/ValidationRuleService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/ValidationRuleService.java
@@ -94,8 +94,12 @@ public class ValidationRuleService {
                         ZonedDateTime.now(), rule.getRuleId(), PageRequest.of(0, 1));
 
                     if (ids.isEmpty()) {
-                        // Rule has no previous version --> just return rule itself
-                        return Collections.singletonList(rule);
+                        // Rule has no older but currently valid version --> return all rules with valid from is greater than today
+
+                        return validationRuleRepository.getByRuleIdAndValidFromIsGreaterThanEqualOrderByIdDesc(
+                            rule.getRuleId(),
+                            ZonedDateTime.now()
+                        );
                     } else {
                         // Return al previous versions and rule itself.
                         return validationRuleRepository

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/ValidationRuleService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/ValidationRuleService.java
@@ -94,7 +94,8 @@ public class ValidationRuleService {
                         ZonedDateTime.now(), rule.getRuleId(), PageRequest.of(0, 1));
 
                     if (ids.isEmpty()) {
-                        // Rule has no older but currently valid version --> return all rules with valid from is greater than today
+                        // Rule has no older but currently valid version
+                        // --> return all rules with valid from is greater than today
 
                         return validationRuleRepository.getByRuleIdAndValidFromIsGreaterThanEqualOrderByIdDesc(
                             rule.getRuleId(),


### PR DESCRIPTION
This PR fixes the Bug that not all future valid rules will be downloaded when only rules which are valid in future exists and nur currently active rule.

This PR currently only contains a Unit-Test which is confirming this behaviour.
Implementation of the fix is still tbd.