### PR TITLE
Fix Certificate Thumbprints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>eu.europa.ec.dgc</groupId>
             <artifactId>dgc-lib</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.vdurmont</groupId>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -10,4 +10,5 @@
     <include file="db/changelog/increase-column-size-for-valueset.xml"/>
     <include file="db/changelog/add-validation-rule-table.xml"/>
     <include file="db/changelog/add-unique-constraints.xml"/>
+    <include file="db/changelog/fix-certificate-thumbprints.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/fix-certificate-thumbprints.xml
+++ b/src/main/resources/db/changelog/fix-certificate-thumbprints.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="fix-thumbprints" author="f11h">
+
+        <sql dbms="h2, mysql">
+            UPDATE trusted_party SET thumbprint = concat('00', thumbprint) WHERE length(thumbprint) = 62;
+        </sql>
+
+        <sql dbms="h2, mysql">
+            UPDATE signer_information SET thumbprint = concat('00', thumbprint) WHERE length(thumbprint) = 62;
+        </sql>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This PR fixes the Certificate Thumbprint calculation. (Missing leading "00")

This PR also includes a Liquibase Changeset to repair invalid entities in the database.


closes #94 