### PR TITLE
Fix loading of Validation Rule Schema from classpath

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/config/ValidationRuleSchemaProvider.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/config/ValidationRuleSchemaProvider.java
@@ -21,8 +21,9 @@
 package eu.europa.ec.dgc.gateway.config;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -45,13 +46,17 @@ public class ValidationRuleSchemaProvider {
     private Schema validationRuleSchema;
 
     @PostConstruct
-    void setup() throws FileNotFoundException {
-        File schemaFile = ResourceUtils.getFile(configProperties.getValidationRuleSchema());
+    void setup() throws FileNotFoundException, IOException {
+        InputStream schemaInputStream = ResourceUtils.getURL(configProperties.getValidationRuleSchema()).openStream();
 
-        validationRuleSchema = SchemaLoader.builder()
-            .schemaJson(new JSONObject(new JSONTokener(new FileInputStream(schemaFile))))
-            .draftV7Support()
-            .build().load().build();
+        try {
+            validationRuleSchema = SchemaLoader.builder()
+                .schemaJson(new JSONObject(new JSONTokener(schemaInputStream)))
+                .draftV7Support()
+                .build().load().build();
+        } finally {
+            schemaInputStream.close();
+        }
     }
 
 }


### PR DESCRIPTION
Out of the box, the gateway is configured to load the validation rule schema from within the classpath, rather than from a file on disk. This was resulting in a failure[1] as `ResourceUtils.getFile()` does not support loading from a classpath.

By switching to use `getURL().openStream()`, both classpath and filesystem loads will work correctly.

[1]: `Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'validationRuleSchemaProvider': Invocation of init method failed; nested exception is java.io.FileNotFoundException: class path resource [validation-rule.schema.json] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/dgcg.jar!/BOOT-INF/classes!/validation-rule.schema.json`