### PR TITLE
Add ValidationRule Check for CertificateType

### DIFF
--- a/src/test/java/eu/europa/ec/dgc/gateway/restapi/controller/ValidationRuleIntegrationTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/restapi/controller/ValidationRuleIntegrationTest.java
@@ -570,6 +570,82 @@ class ValidationRuleIntegrationTest {
     }
 
     @Test
+    void testValidationRuleInvalidIdPrefix() throws Exception {
+        X509Certificate signerCertificate = trustedPartyTestHelper.getCert(TrustedPartyEntity.CertificateType.UPLOAD, countryCode);
+        PrivateKey signerPrivateKey = trustedPartyTestHelper.getPrivateKey(TrustedPartyEntity.CertificateType.UPLOAD, countryCode);
+        String authCertHash = trustedPartyTestHelper.getHash(TrustedPartyEntity.CertificateType.AUTHENTICATION, countryCode);
+
+        ValidationRule validationRule = getDummyValidationRule();
+        validationRule.setIdentifier("TR-EU-0001");
+        validationRule.setCertificateType("Vaccination");
+
+        String payload = new SignedStringMessageBuilder()
+            .withSigningCertificate(certificateUtils.convertCertificate(signerCertificate), signerPrivateKey)
+            .withPayload(objectMapper.writeValueAsString(validationRule))
+            .buildAsString();
+
+        mockMvc.perform(post("/rules")
+            .content(payload)
+            .contentType("application/cms-text")
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getThumbprint(), authCertHash)
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getDistinguishedName(), authCertSubject)
+        )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("0x250"));
+
+        validationRule.setIdentifier("VR-EU-0001");
+        validationRule.setCertificateType("Test");
+
+        payload = new SignedStringMessageBuilder()
+            .withSigningCertificate(certificateUtils.convertCertificate(signerCertificate), signerPrivateKey)
+            .withPayload(objectMapper.writeValueAsString(validationRule))
+            .buildAsString();
+
+        mockMvc.perform(post("/rules")
+            .content(payload)
+            .contentType("application/cms-text")
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getThumbprint(), authCertHash)
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getDistinguishedName(), authCertSubject)
+        )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("0x250"));
+
+        validationRule.setIdentifier("RR-EU-0001");
+        validationRule.setCertificateType("Vaccination");
+
+        payload = new SignedStringMessageBuilder()
+            .withSigningCertificate(certificateUtils.convertCertificate(signerCertificate), signerPrivateKey)
+            .withPayload(objectMapper.writeValueAsString(validationRule))
+            .buildAsString();
+
+        mockMvc.perform(post("/rules")
+            .content(payload)
+            .contentType("application/cms-text")
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getThumbprint(), authCertHash)
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getDistinguishedName(), authCertSubject)
+        )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("0x250"));
+
+        validationRule.setIdentifier("GR-EU-0001");
+        validationRule.setCertificateType("Vaccination");
+
+        payload = new SignedStringMessageBuilder()
+            .withSigningCertificate(certificateUtils.convertCertificate(signerCertificate), signerPrivateKey)
+            .withPayload(objectMapper.writeValueAsString(validationRule))
+            .buildAsString();
+
+        mockMvc.perform(post("/rules")
+            .content(payload)
+            .contentType("application/cms-text")
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getThumbprint(), authCertHash)
+            .header(dgcConfigProperties.getCertAuth().getHeaderFields().getDistinguishedName(), authCertSubject)
+        )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("0x250"));
+    }
+
+    @Test
     void testDelete() throws Exception {
         long validationRulesInDb = validationRuleRepository.count();
 

--- a/src/test/java/eu/europa/ec/dgc/gateway/testdata/CertificateTestUtils.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/testdata/CertificateTestUtils.java
@@ -53,7 +53,7 @@ public class CertificateTestUtils {
         validationRule.setLogic(jsonNodeFactory.objectNode().set("field1", jsonNodeFactory.textNode("value1")));
         validationRule.setValidTo(ZonedDateTime.now().plus(1, ChronoUnit.WEEKS));
         validationRule.setValidFrom(ZonedDateTime.now().plus(3, ChronoUnit.DAYS));
-        validationRule.setCertificateType("Vaccination");
+        validationRule.setCertificateType("General");
         validationRule.setDescription(List.of(new ValidationRule.DescriptionItem("en", "de".repeat(10))));
         validationRule.setEngine("CERTLOGIC");
         validationRule.setEngineVersion("1.0.0");


### PR DESCRIPTION
This PR adds the ValidationRule Check on upload that the CertificateType property matches the used prefix in the id.

See #104 for the mapping.

closes #104