### PR TITLE
Chore: Update SpringBoot 2.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.5</version>
+        <version>2.6.6</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <h2.version>2.1.210</h2.version>
         <hibernate.version>5.6.5.Final</hibernate.version>
         <dgc.lib.version>1.3.1</dgc.lib.version>
-        <jackson.databind.version>2.13.2.1</jackson.databind.version>
         <!-- plugins -->
         <plugin.maven-assembly.version>3.3.0</plugin.maven-assembly.version>
         <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>
@@ -266,12 +265,6 @@
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-spring</artifactId>
             <version>${shedlock.version}</version>
-        </dependency>
-        <!-- Explicitly needed due to https://nvd.nist.gov/vuln/detail/CVE-2020-36518 until core is updated -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update to SpringBoot 2.6.6 to mitigate https://tanzu.vmware.com/security/cve-2022-22965
