### PR TITLE
Fix: Sporadic failing Unit-Test

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -19,7 +19,11 @@
     <suppress>
         <notes>Only affecting example code shipped with tomcat.</notes>
         <cve>CVE-2022-34305</cve>
-
+    </suppress>
+    <suppress>
+        <notes>DGCG is not using YML User Input</notes>
+        <cve>CVE-2022-38751</cve>
+        <cve>CVE-2022-38752</cve>
     </suppress>
 
 </suppressions>

--- a/src/test/java/eu/europa/ec/dgc/gateway/service/SignerInformationServiceTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/service/SignerInformationServiceTest.java
@@ -33,6 +33,7 @@ import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -68,9 +69,9 @@ class SignerInformationServiceTest {
     private static final String countryCode = "EU";
     private static final String dummySignature = "randomStringAsSignatureWhichIsNotValidatedInServiceLevel";
 
-    private static final ZonedDateTime now = ZonedDateTime.now();
-    private static final ZonedDateTime nowMinusOneMinute = ZonedDateTime.now().minusMinutes(1);
-    private static final ZonedDateTime nowMinusOneHour = ZonedDateTime.now().minusHours(1);
+    private final static ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+    private final static ZonedDateTime nowMinusOneMinute = now.minusMinutes(1);
+    private final static ZonedDateTime nowMinusOneHour = now.minusHours(1);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
This PR fixes a Unit-Test which failes sometimes because of millisecond part of the used timestamps.

fixes #189 